### PR TITLE
fixed the woff2 parsing?

### DIFF
--- a/lib-font.js
+++ b/lib-font.js
@@ -87,13 +87,13 @@ class Font extends EventManager {
     async parseBasicData(type) {
         return loadTableClasses().then(createTable => {
             if (type === `SFNT`) {
-                this.opentype = new SFNT(this.fontData, createTable);
+                this.opentype = new SFNT(this, this.fontData, createTable);
             }
             if (type === `WOFF`) {
-                this.opentype = new WOFF(this.fontData, createTable);
+                this.opentype = new WOFF(this, this.fontData, createTable);
             }
             if (type === `WOFF2`) {
-                this.opentype = new WOFF2(this.fontData, createTable);
+                this.opentype = new WOFF2(this, this.fontData, createTable);
             }
             return this.opentype;
         });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:browser": "run-p test:server test:puppeteer",
     "test:server": "node ./testing/browser/server.js",
     "test:puppeteer": "node ./testing/browser/puppeteer.js",
-    "test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --verbose=false ./testing/node/"
+    "test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --verbose=false ./testing/node/",
+    "test:manual": "http-server -o testing/manual/index.html"
   },
   "repository": {
     "type": "git",
@@ -39,10 +40,14 @@
   "devDependencies": {
     "cross-env": "^7.0.2",
     "express": "^4.17.1",
+    "http-server": "^0.12.3",
     "jest": "^26.6.3",
     "npm-run-all": "^4.1.5",
     "open-cli": "^6.0.1",
     "prettier": "^2.1.1",
     "puppeteer": "^5.3.1"
+  },
+  "dependencies": {
+    "brotli": "^1.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lib-font",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A JS based OpenType font inspector",
   "main": "./lib-font.js",
   "exports": "./lib-font.js",

--- a/src/opentype/sfnt.js
+++ b/src/opentype/sfnt.js
@@ -7,7 +7,7 @@ import lazy from "../lazy.js";
  * See https://docs.microsoft.com/en-us/typography/opentype/spec/overview for more information
  */
 class SFNT extends SimpleTable {
-  constructor(dataview, createTable) {
+  constructor(font, dataview, createTable) {
     const { p } = super({ offset: 0, length: 12 }, dataview, `sfnt`);
 
     this.version = p.uint32;

--- a/src/opentype/tables/advanced/GPOS.js
+++ b/src/opentype/tables/advanced/GPOS.js
@@ -2,7 +2,7 @@ import { CommonLayoutTable } from "../common-layout-table.js";
 
 class GPOS extends CommonLayoutTable {
   constructor(dict, dataview) {
-    super(dict, dataview);
+    super(dict, dataview, `GPOS`);
   }
   getLookup(lookupIndex) {
     return super.getLookup(lookupIndex, `GPOS`);

--- a/src/opentype/tables/advanced/GSUB.js
+++ b/src/opentype/tables/advanced/GSUB.js
@@ -2,7 +2,7 @@ import { CommonLayoutTable } from "../common-layout-table.js";
 
 class GSUB extends CommonLayoutTable {
   constructor(dict, dataview) {
-    super(dict, dataview);
+    super(dict, dataview, `GSUB`);
   }
 
   getLookup(lookupIndex) {

--- a/src/opentype/tables/common-layout-table.js
+++ b/src/opentype/tables/common-layout-table.js
@@ -15,8 +15,8 @@ import lazy from "../../lazy.js";
  * See https://docs.microsoft.com/en-us/typography/opentype/spec/GPOS
  */
 class CommonLayoutTable extends SimpleTable {
-  constructor(name, dict, dataview) {
-    const { p, tableStart } = super(name, dict, dataview);
+  constructor(dict, dataview, name) {
+    const { p, tableStart } = super(dict, dataview, name);
 
     this.majorVersion = p.uint16;
     this.minorVersion = p.uint16;

--- a/src/opentype/woff.js
+++ b/src/opentype/woff.js
@@ -10,7 +10,7 @@ const gzipDecode = globalThis.pako ? globalThis.pako.inflate : undefined;
  * See https://docs.microsoft.com/en-us/typography/opentype/spec/overview for font information
  */
 class WOFF extends SimpleTable {
-  constructor(dataview, createTable) {
+  constructor(font, dataview, createTable) {
     const { p } = super({ offset: 0, length: 44 }, dataview, `woff`);
 
     this.signature = p.tag;

--- a/src/opentype/woff2.js
+++ b/src/opentype/woff2.js
@@ -56,18 +56,12 @@ class WOFF2 extends SimpleTable {
     let buffer = dataview.buffer.slice(dictOffset);
 
     if (brotliDecode) {
-      const decoded = brotliDecode(
-        new Uint8Array(buffer)
-      );
+      const decoded = brotliDecode(new Uint8Array(buffer));
       buildWoff2LazyLookups(this, decoded, createTable);
-    }
-
-    else if (nativeBrotliDecode) {
+    } else if (nativeBrotliDecode) {
       const decoded = new Uint8Array(nativeBrotliDecode(buffer));
       buildWoff2LazyLookups(this, decoded, createTable);
-    }
-
-    else {
+    } else {
       const msg = `no brotli decoder available to decode WOFF2 font`;
       if (font.onerror) font.onerror(msg);
     }
@@ -124,7 +118,9 @@ function buildWoff2LazyLookups(woff2, decoded, createTable) {
   woff2.directory.forEach((entry) => {
     lazy(woff2.tables, entry.tag.trim(), () => {
       const start = entry.offset;
-      const end = start + (entry.transformLength ? entry.transformLength : entry.origLength);
+      const end =
+        start +
+        (entry.transformLength ? entry.transformLength : entry.origLength);
       const data = decoded.slice(start, end);
       return createTable(
         woff2.tables,

--- a/testing/manual/index.html
+++ b/testing/manual/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>LibFont unit tests</title>
+        <script src="/lib/inflate.js" defer></script>
+        <script src="/lib/unbrotli.js" defer></script>
+        <script src="/lib-font.js" type="module" defer></script>
+        <script src="./index.js" type="module" defer></script>
+    </head>
+    <body>
+        <h1>Please open dev tools for now</h1>
+    </body>
+</html>

--- a/testing/manual/index.js
+++ b/testing/manual/index.js
@@ -1,0 +1,43 @@
+const font = new Font("woff2 testing");
+font.onerror = (evt) => console.error(evt);
+font.onload = (evt) => {
+  let font = evt.detail.font;
+
+  const { GSUB } = font.opentype.tables;
+  processGSUB(GSUB);
+};
+
+const fonts = [
+  `/fonts/broken/BrushPosterGrotesk.woff2`,
+  `/fonts/broken/135abd30-1390-4f9c-b6a2-d843157c3468.woff2`, // No GSUB table?
+  `/fonts/broken/64017d81-9430-4cba-8219-8f5cc28b923e.woff2`, // No GSUB table?
+  `/fonts/broken/proximanova-regular-webfont.woff2`,
+];
+
+font.src = fonts[0];
+
+function processGSUB(GSUB) {
+  let scripts = GSUB.getSupportedScripts();
+
+  scripts.forEach((script) => {
+    let langsys = GSUB.getSupportedLangSys(script);
+
+    langsys.forEach((lang) => {
+      let langSysTable = GSUB.getLangSysTable(script, lang);
+      let features = GSUB.getFeatures(langSysTable);
+
+      features.forEach((feature) => {
+        const lookupIDs = feature.lookupListIndices;
+
+        lookupIDs.forEach((id) => {
+          const lookup = GSUB.getLookup(id);
+          const cnt = lookup.subTableCount;
+          const s = cnt !== 1 ? "s" : "";
+          console.log(
+            `lookup type ${lookup.lookupType} in ${lang}, lookup ${id}, ${cnt} subtable${s}`
+          );
+        });
+      });
+    });
+  });
+}


### PR DESCRIPTION
closes #115  by updating the woff2 table data parsing code, as well as using Node's native brotli decoding (via the `zlib` module) rather than trying to `import` the `lib/unbrotli.js` file, which isn't a module.\

@RoelN if you create a dir called `fonts/broken` and put the fonts from #114 in there, the new `npm run test:manual` should allow you to verify things work in the browser, with the following `test.js` file that you can run with `node test.js` to verify things work on the node side, too:

```js
import { Font } from "./lib-font.js";

const font = new Font("woff2 testing");
font.src = `./fonts/broken/BrushPosterGrotesk.woff2`;
font.onerror = (evt) => console.error(evt);
font.onload = (evt) => {
  let font = evt.detail.font;

  const { GSUB } = font.opentype.tables;
  let scripts = GSUB.getSupportedScripts();

  scripts.forEach((script) => {
    let langsys = GSUB.getSupportedLangSys(script);

    langsys.forEach((lang) => {
      let langSysTable = GSUB.getLangSysTable(script, lang);
      let features = GSUB.getFeatures(langSysTable);

      features.forEach((feature) => {
        const lookupIDs = feature.lookupListIndices;

        lookupIDs.forEach((id) => {
          const lookup = GSUB.getLookup(id);

          const cnt = lookup.subTableCount;
          const s = cnt !== 1 ? "s" : "";
          console.log(
            `lookup type ${lookup.lookupType} in ${lang}, lookup ${id}, ${cnt} subtable${s}`
          );
        });
      });
    });
  });
};

```