### PR TITLE
Fix typo in loca.js: `hmtx` should be `head`

### DIFF
--- a/src/opentype/tables/simple/ttf/loca.js
+++ b/src/opentype/tables/simple/ttf/loca.js
@@ -12,7 +12,7 @@ class loca extends SimpleTable {
 
     const n = tables.maxp.numGlyphs + 1; // "plus one" because the offset list needs one extra element to determine the block length for the last supported glyph.
 
-    if (tables.hmtx.indexToLocFormat === 0) {
+    if (tables.head.indexToLocFormat === 0) {
       this.x2 = true;
       lazy(this, `offsets`, () => [...new Array(n)].map((_) => p.Offset16));
     } else {

--- a/testing/browser/tests/test-SFNT.js
+++ b/testing/browser/tests/test-SFNT.js
@@ -259,6 +259,7 @@ function testSFNT(SFNT, isTTF) { try {
         assertNotEqual(loca, undefined, `loca EXISTS`);
         const glyf = tables.glyf;
         assertNotEqual(glyf, undefined, `glyf EXISTS`);
+        assertEqual(!!loca.x2, tables.head.indexToLocFormat === 0, `Correct interpretation of indexToLocFormat`);
         indent();
     }
 


### PR DESCRIPTION
`indexToLocFormat` is a property of the head table.