### PR TITLE
Better condition for checking values in `load`

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -183,7 +183,7 @@ class ParsedData {
       let props = Object.getOwnPropertyDescriptor(struct, p);
       if (props.get) {
         this[p] = props.get.bind(this);
-      } else if (props.value) {
+      } else if (props.value !== undefined) {
         this[p] = props.value;
       }
     });


### PR DESCRIPTION
`props.value` would be falsy when it's 0, which is a valid value; for example in the case of `indexToLocFormat`.